### PR TITLE
Fix/context menu

### DIFF
--- a/src/components/contextMenu/AposContextMenu.vue
+++ b/src/components/contextMenu/AposContextMenu.vue
@@ -2,6 +2,7 @@
   <div
     class="apos-context-menu" :class="classList"
     ref="component" :style="localCssVar"
+    :data-apos-context-menu="uid"
   >
     <!-- TODO refactor buttons to take a single config obj -->
     <AposButton
@@ -43,6 +44,7 @@
 import AposContextMenuItem from './AposContextMenuItem';
 import AposContextMenuTip from './AposContextMenuTip';
 import AposButton from './../button/AposButton';
+import AposHelpers from '../../mixins/AposHelpersMixin';
 
 export default {
   name: 'AposContextMenu',
@@ -51,6 +53,7 @@ export default {
     AposContextMenuTip,
     AposButton
   },
+  mixins: [AposHelpers],
   props: {
     menu: {
       type: Array,
@@ -85,11 +88,13 @@ export default {
   data() {
     return {
       open: false,
-      vueId: this.$options._scopeId,
-      tipWidth: 27
+      tipWidth: '27'
     };
   },
   computed: {
+    uid() {
+      return this.generateId();
+    },
     classList() {
       const classes = [];
       classes.push(`apos-context-menu--origin-${this.origin}`);
@@ -135,7 +140,7 @@ export default {
     },
     clicks (event) {
       // if user clicks outside menu component, close menu
-      if (!event.target.closest(`[${this.vueId}]`)) {
+      if (!event.target.closest(`[data-apos-context-menu="${this.uid}"]`)) {
         this.open = false;
         this.unbind();
       }

--- a/src/components/contextMenu/AposContextMenu.vue
+++ b/src/components/contextMenu/AposContextMenu.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="apos-context-menu" :class="classList"
-    ref="component"
+    ref="component" :style="localCssVar"
   >
     <!-- TODO refactor buttons to take a single config obj -->
     <AposButton
@@ -15,11 +15,12 @@
       class="apos-primary-scrollbar apos-context-menu__popup"
       :class="{'is-visible': open}" ref="popup"
       :aria-hidden="open ? 'false' : 'true'"
-      role="dialog" :style="position"
+      role="dialog"
     >
       <AposContextMenuTip
         :align="tipAlignment"
         :origin="origin"
+        :width="tipWidth"
       />
       <div class="apos-context-menu__pane">
         <slot>
@@ -85,7 +86,7 @@ export default {
     return {
       open: false,
       vueId: this.$options._scopeId,
-      position: ''
+      tipWidth: 27
     };
   },
   computed: {
@@ -105,13 +106,14 @@ export default {
     },
     buttonState() {
       return this.open ? ['active'] : null;
+    },
+    localCssVar() {
+      // Set the CSS custom property for this specific context menu.
+      return { '--tip-width': `${this.tipWidth}px` };
     }
   },
   watch: {
     open(newVal, oldVal) {
-      if (newVal) {
-        this.position = this.calculatePosition();
-      }
       this.$emit('open', newVal);
     }
   },
@@ -119,12 +121,10 @@ export default {
     bind() {
       document.addEventListener('click', this.clicks);
       document.addEventListener('keydown', this.keyboard);
-      window.addEventListener('resize', this.positionPopup);
     },
     unbind() {
       document.removeEventListener('click', this.clicks);
       document.removeEventListener('keydown', this.keyboard);
-      window.removeEventListener('resize', this.positionPopup);
     },
     keyboard(event) {
       // if user hits esc, close menu
@@ -150,51 +150,6 @@ export default {
     },
     menuItemClicked(action) {
       this.$emit('item-clicked', action);
-    },
-    positionPopup() {
-      this.position = this.calculatePosition();
-    },
-    // TODO this is proving a difficult way to handle positioning.
-    // Ideally we'd be using absolute positioning to anchor to the button and float above or below
-    // to display the menu pane. Initial attempts at this proved difficult for z-index and overflow clipping reasons.
-    calculatePosition() {
-      const button = this.$refs.button.$el;
-      const popup = this.$refs.popup;
-      const rect = button.getBoundingClientRect();
-      const buttonHeight = button.offsetHeight;
-      // getBoundingClientRect gives us the true x,y,etc of an el from the viewport but
-      // position:fixed inside position:fixed is positioned relatively to the first, account for it
-      let contextRect = {
-        top: 0,
-        left: 0
-      };
-      if (button.closest('[data-apos-modal-inner]')) {
-        contextRect = button.closest('[data-apos-modal-inner]').getBoundingClientRect();
-      }
-      let top, left;
-
-      if (this.origin === 'above') {
-        // above
-        top = rect.top - contextRect.top - popup.offsetHeight - 15;
-      } else {
-        // below
-        top = rect.top - contextRect.top + buttonHeight + 15;
-      }
-
-      if (this.tipAlignment === 'center') {
-        // center
-        const buttonCenter = rect.left - contextRect.left + (button.offsetWidth / 2);
-        left = buttonCenter - (popup.offsetWidth / 2);
-
-      } else if (this.tipAlignment === 'right') {
-        // right
-        left = rect.left - contextRect.left + button.offsetWidth - popup.offsetWidth + 15;
-      } else {
-        // left
-        left = rect.left - contextRect.left - 15;
-      }
-
-      return `top: ${top}px; left: ${left}px`;
     }
   }
 };
@@ -205,7 +160,7 @@ export default {
 
   .apos-context-menu {
     position: relative;
-    display: inline;
+    display: inline-block;
   }
 
   .apos-context-menu--unpadded .apos-context-menu__pane  {
@@ -214,7 +169,7 @@ export default {
 
   .apos-context-menu__popup {
     z-index: 2;
-    position: fixed;
+    position: absolute;
     display: inline-block;
     color: var(--a-text-primary);
     opacity: 0;
@@ -222,11 +177,33 @@ export default {
     transform: scale(0.98) translateY(-8px);
     transform-origin: top left;
     transition: scale 0.15s ease, translateY 0.15s ease;
+
+    $popup-vert-offset: 16px;
+    .apos-context-menu--origin-above & {
+      bottom: calc(100% + #{$popup-vert-offset});
+      // bottom: 0;
+    }
+    .apos-context-menu--origin-below & {
+      top: calc(100% + #{$popup-vert-offset});
+    }
+    .apos-context-menu--tip-alignment-center & {
+      left: 50%;
+      transform: translatex(-50%);
+    }
+    // We're positioning with the popup-tip in the center of the parent,
+    // so we adjust based on the tip's width and the tip offset.
+    .apos-context-menu--tip-alignment-left & {
+      left: 50%;
+      transform: translatex(calc(#{-$menuTipOffset} - var(--tip-width)/2));
+    }
+    .apos-context-menu--tip-alignment-right & {
+      right: 50%;
+      transform: translatex(calc(#{$menuTipOffset} + var(--tip-width)/2));
+    }
   }
 
   .apos-context-menu__popup.is-visible {
     opacity: 1;
-    transform: scale(1) translateY(0);
     pointer-events: auto;
   }
 

--- a/src/components/contextMenu/AposContextMenuTip.vue
+++ b/src/components/contextMenu/AposContextMenuTip.vue
@@ -1,9 +1,10 @@
 <template>
   <!-- Disabling since the SVG is mostly not active vue template code. -->
   <!-- eslint-disable vue/max-attributes-per-line -->
+  <!-- NOTE: the `width` att -->
   <svg
     :class="[alignmentModifier, originModifier]"
-    class="apos-context-menu__tip" width="27px" height="13px" viewBox="0 0 27 13" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+    class="apos-context-menu__tip" :width="width" :height="height" :viewBox="`0 0 ${width} ${height}`" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
   >
     <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
       <g transform="translate(-0.375000, 1.312500)">
@@ -26,9 +27,16 @@ export default {
     origin: {
       type: String,
       required: true
+    },
+    width: {
+      type: String,
+      default: '27px'
     }
   },
   computed: {
+    height() {
+      return this.width * 0.4815;
+    },
     alignmentModifier () {
       return `apos-context-menu__tip--alignment-${this.align}`;
     },
@@ -45,7 +53,7 @@ export default {
   }
 
   .apos-context-menu__tip--alignment-left {
-    left: 20px;
+    left: $menuTipOffset;
   }
 
   .apos-context-menu__tip--alignment-center {
@@ -56,7 +64,7 @@ export default {
   }
 
   .apos-context-menu__tip--alignment-right {
-    right: 20px;
+    right: $menuTipOffset;
   }
 
   .apos-context-menu__tip--origin-below {

--- a/src/components/mediaManager/AposMediaManager.vue
+++ b/src/components/mediaManager/AposMediaManager.vue
@@ -7,6 +7,7 @@
 <template>
   <AposModal
     :modal="modal"
+    class="apos-media-manager"
     @inactive="modal.active = false" @show-modal="modal.showModal = true"
     @esc="cancel" @no-modal="$emit('safe-close')"
   >
@@ -238,6 +239,12 @@ export default {
 
 <style lang="scss" scoped>
 @import '../../scss/_mixins';
+
+  .apos-media-manager /deep/ .apos-media-manager-toolbar {
+    position: relative;
+    z-index: 3;
+  }
+
 .apos-media-manager__empty {
   display: flex;
   justify-content: center;

--- a/src/scss/_theme.scss
+++ b/src/scss/_theme.scss
@@ -26,6 +26,8 @@ $spacing-triple: $spacing-base * 3;
 $input-padding: $spacing-base * 1.5;
 $boolean-padding: $spacing-double;
 
+$menuTipOffset: 20px;
+
 @mixin apos-primary-mixin ($color) {
   --a-primary: #{$color};
   --a-primary-50: #{transparentize($color, 0.5)};


### PR DESCRIPTION
Since storybook isn't in core yet, and might not be for a few days, I want to keep this moving in here.

This solves issues around scrolling (big one), z-index, and auto-closing. The remaining issue is specifically in Media Manager, where a wider context menu (like AposTagApply) can get cut off due to the overflow on small-ish screens. I'm talking tablet-width, where we're going to have a lot of things to figure out anyway. I suggest we go with this approach and work out the tablet experience along with other elements of that view later (hopefully not too much later).

Closes #89 