### PR TITLE
Removes spinner until needed

### DIFF
--- a/src/components/button/AposButton.vue
+++ b/src/components/button/AposButton.vue
@@ -3,9 +3,9 @@
     type="button" @click="click"
     class="apos-button"
     :class="modifierClass" :tabindex="tabindex"
-    :busy="busy" :disabled="isDisabled"
+    :disabled="isDisabled"
   >
-    <AposSpinner :color="spinnerColor" />
+    <AposSpinner :color="spinnerColor" v-if="busy" />
     <div class="apos-button__content">
       <component
         :size="15" class="apos-button__icon"


### PR DESCRIPTION
The spinner has been hanging out in the DOM. Is there a reason for that? It doesn't seem to enable any transition.